### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@
 ##### Фреймворки, среды разработок, библиотеки
 * [1C](https://t.me/ru_1c) — Чат про "1С:Предприятие"
 * [Angular.js](https://t.me/angular_js) — Чат про AngularJS 1.x
-* [Angular 2](https://t.me/angular2) — Чат про AngularJS 2.x
+* [Angular](https://t.me/angular_ru) - Чат про Angular (4.x+)
 * [Django](https://t.me/pydjango) — Чат про Django
 * [Emacs](https://t.me/emacs_ru) — Чат про Emacs
 * [Joomla! по-русски](https://t.me/joomlaru) — Чат про Joomla!

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@
 * [VR Journal](https://t.me/VR_Journal) — Уютненько о VR/AR технологиях
 * [EasyCoding Team](https://t.me/easycoding) — Канал EasyCoding Team: новости, статьи о разработке и администрировании, HOWTO
 * [anykeynotes](https://t.me/anykeynotes) — Записки старого эникейщика.
+* [Angular 2](https://t.me/angular2) — Новости из мира Angular (js framework)
 
 [(Назад к меню)](#Меню)
 


### PR DESCRIPTION
Указал чат вместо канала. Настоящий чат по Angular (4.x) находится по https://t.me/angular_ru. Изначально указанная ссылка на канал а не на чат