### PR TITLE
add dead2pizza

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@
 * [Amazon AWS notes](https://t.me/aws_notes) — Канал про AWS от Amazon
 * [Мониторим ИТ](https://t.me/monitorim_it) — Канал об управлении ИТ (мониторинг, ITSM, etc.)
 * [Пятничный деплой](https://t.me/count0_digest) — Подборка ссылок, статей и постов из мира DevOps\SRE\разработки.
-* [2pizza Software](https://t.me/topizza) — шуточки из hangops и не только.
+* [Тупица Мёртв](https://t.me/dead2pizza) — шуточки из hangops и не только.
 * [Записки админа](https://t.me/SysadminNotes) — Статьи, рекомендации мысли про администрирование серверов
 * [i_odmin](https://t.me/i_odmin) — Канал про сисадминов
 * [DevOps40.ru](https://t.me/devops40) — Канал новостей DevOps 40. Анонсы мероприятий, статьи, книги.


### PR DESCRIPTION
Replaces `toopizza` channel by `dead2pizza` because first channel was stolen.