### PR TITLE
Adding eu n uk chats n small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,7 @@
 * [JUGNsk](https://t.me/jugnsk) — Новосибирская группа Java User Group
 * [NSK IT events](https://t.me/NSKITevents) — Митапы и другие айтишные события в Новосибирске.
 * [Docker Novosibirsk](https://t.me/dockernsk) — Чат Docker Новосибирск
-##### Зарубежные русскоязычные IT-сообщества
+##### Русскоязычные IT-сообщества Ближнего Зарубежья
 * [iOS Community – Kharkiv](https://t.me/ios_kharkiv) — Сообщество iOS-программистов Харькова
 * [Kharkiv iOS Peerlab](https://t.me/kharkiv_ios) — Чат для связи людей, которые собираются на [iOS-пирлабы по субботам в Харькове](https://www.meetup.com/Kharkiv-iOS-Peerlab/)
 * [1с Чат РБ](https://t.me/One1c_Blr) — Связанные одним 1С в РБ.

--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,9 @@
 * [JUGNsk](https://t.me/jugnsk) — Новосибирская группа Java User Group
 * [NSK IT events](https://t.me/NSKITevents) — Митапы и другие айтишные события в Новосибирске.
 * [Docker Novosibirsk](https://t.me/dockernsk) — Чат Docker Новосибирск
+
+[(Назад к меню)](#Меню)
+
 ##### Русскоязычные IT-сообщества Ближнего Зарубежья
 * [iOS Community – Kharkiv](https://t.me/ios_kharkiv) — Сообщество iOS-программистов Харькова
 * [Kharkiv iOS Peerlab](https://t.me/kharkiv_ios) — Чат для связи людей, которые собираются на [iOS-пирлабы по субботам в Харькове](https://www.meetup.com/Kharkiv-iOS-Peerlab/)

--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,14 @@
 
 [(Назад к меню)](#Меню)
 
+##### Европейские русскоязычные IT-сообщества
+######Великобритания  
+* [Гоняю Ваш JSON, дорого](https://t.me/london_ru) — Лондонское сообщество Data Scientists, Machine Learning Engineers, Machine Learning Researchers, Quantitative Researcher, Backend Developers, Data Engineers, MLOps, etc  
+######ФРГ (Федеративная Республика Германия)
+* [Чат серьезных экспатов Мюнхена ](https://t.me/muenchentraktor) — Мюнхенский чат ИТшников.
+    
+[(Назад к меню)](#Меню)
+
 ##### Электроника, микроконтроллеры и встраиваемые системы
 * [Catethysis](https://t.me/telecatethysis_main) — Чат про электронику, программирование микроконтроллеров, stm32
 * [pro.embedded](https://t.me/proembedded) — Чат про встраиваемые системы


### PR DESCRIPTION
1. add two chats ... from uk and from De 
2. rename paragraph Зарубежные русскоязычные IT-сообщества to Русскоязычные IT-сообщества Ближнего Зарубежья 
3. ( small fix ) at the end of Российские региональные IT-сообщества paragraph and back to menu button ( [(Назад к меню)](#Меню) )